### PR TITLE
Simple fix the allow dry run not to eat itself.

### DIFF
--- a/startBoilerplate.py
+++ b/startBoilerplate.py
@@ -127,4 +127,5 @@ for path in pathiter:
             os.rename(path,newname)
         print(f'Renamin file from "{path[folderPrintIndex:]}" to "{newname[folderPrintIndex:]}"')
 
-os.remove(args[0])
+if not dryRun:
+    os.remove(args[0])


### PR DESCRIPTION
Annoying to have dry run option enabled and have the file delete itself before it does the actual work.

Checks the dryRun variable and if true, it no longer removes itself.